### PR TITLE
改进了后台消费者线程的逻辑

### DIFF
--- a/test/multi thread/mtest.cc
+++ b/test/multi thread/mtest.cc
@@ -21,13 +21,14 @@ void* thdo(void* args)
 
 int main(int argc, char** argv)
 {
+    int nThreads = 20;
     LOG_INIT("log", "myname", 3);
     uint64_t start_ts = get_current_millis();
-    pthread_t tids[5];
-    for (int i = 0;i < 5; ++i)
+    pthread_t tids[nThreads];
+    for (int i = 0;i < nThreads; ++i)
     	pthread_create(&tids[i], NULL, thdo, NULL);
 
-    for (int i = 0;i < 5; ++i)
+    for (int i = 0;i < nThreads; ++i)
 	pthread_join(tids[i], NULL);
     uint64_t end_ts = get_current_millis();
     printf("time use %lums\n", end_ts - start_ts);


### PR DESCRIPTION
ringlog的环形链表缓冲区拥有让消费者线程一定程度上降低互斥锁使用的潜力。

原始逻辑在日志写入压力非常大的时候，消费者线程有可能由于生产者线程很多而难以获得到互斥锁，从而延缓持久化的过程，从而造成环形缓冲区扩展数量用尽之后丢弃大量的日志。

改进的逻辑先尝试直接判断当前buffer是否可以持久化（FULL），可以的话直接持久化，不行的话再进入加锁等待逻辑；在后续持久化完成之后，需要让消费者指针前进的时候其实也是可以无锁化完成的（为了这一逻辑的线程安全性，在生产者线程和消费者线程中，保证了先移动指针，再设置相应flag的逻辑）

实测在开20条线程写入日志的时候，原始逻辑会丢弃大量日志，而改进的逻辑能完成写入过程，测试是在一台16核的ubuntu服务器上进行的

关于消费者指针移动无锁线程安全性的讨论：
①消费者指针会越过生产者指针吗？由于保证了先移走生产者指针再设置FULL的逻辑，能被消费者持久化的FULL块，生产者指针一定不在这里而是在后面（由生产者自己出让，或者消费者去抢夺都是如此）
②new buffer扩展链表环的时候，不加锁移动消费者指针会导致线程不安全吗？由于保证了先移动生产者指针再设置flag为FULL的逻辑，再链接链表环的时候，当前生产者指针对应的buffer是FREE，是不会被消费者去持久化的（消费者去抢夺逻辑也不行，因为此时生产者是持有锁的），只有链表链接完成后，才会设置其flag为FULL，允许其持久化。